### PR TITLE
Feature/deletion improvements

### DIFF
--- a/src/scripts/TailoringEntry.js
+++ b/src/scripts/TailoringEntry.js
@@ -530,12 +530,28 @@ class TailoringEntry {
     }
 
     /**
-     * Removes this entry's UI from the popup interface, deletes its runtime
-     * data, and saves the updated data to storage.
+     * Removes this entry's UI and data.
      */
     delete() {
-        this.element.remove();
+        // Listen for the end of the deletion animation before actually removing
+        // the element from the DOM.
+        this.element.addEventListener("animationend", e => {
+            // Only proceed if this was the deletion animation.
+            if (e.animationName !== "deleteEntry") {
+                return;
+            }
 
+            this.element.remove();
+        });
+
+        // Get and apply this entry's height in-line for animation purposes.
+        const entryHeight = this.element.getBoundingClientRect().height;
+        this.element.style.setProperty("--entry-height", `${entryHeight}px`);
+
+        // Apply a data attribute to trigger the deletion animation.
+        this.element.dataset.isBeingDeleted = true;
+
+        // Delete this entry's data and save the update to storage.
         addonData.runtime.tailoringEntries.splice(this.index, 1);
         addonData.runtime.tailoringEntryObjects.splice(this.index, 1);
 

--- a/src/scripts/TailoringEntry.js
+++ b/src/scripts/TailoringEntry.js
@@ -222,7 +222,7 @@ class TailoringEntry {
             const domainArray = this.tokenField.getItems().map(i => i.name);
             this.settings.domains = domainArray;
 
-            saveTailoringEntries("entry-domains", [this.settings.id]);
+            saveTailoringEntries("entry-domains");
         });
 
         // Respond to keyboard events in the TokenField.

--- a/src/scripts/addon.js
+++ b/src/scripts/addon.js
@@ -225,34 +225,56 @@ class TailoredSearch {
             // If this result has no applicable entry, remove any existing
             // alterations applied by the extension.
             if (!tailoringEntry) {
-                delete thisResult.dataset.tailoringEntryId;
-                thisResult.style.opacity = null;
-                thisResult.style.display = null;
-                qs(this.treatmentPanelSelector, thisResult).remove();
+                this.removeTreatment(thisResult);
                 return;
             }
 
-            // If this result's treatment is set to an opacity of 0, screen the
-            // result completely.
-            if (tailoringEntry.treatment.opacity === 0) {
-                thisResult.style.display = "none";
-                return;
-            }
-
-            // Ensure this result element is visible and apply it's treatment's
-            // opacity setting directly.
-            thisResult.style.display = null;
-            thisResult.style.opacity = tailoringEntry.treatment.opacity;
-
-            const treatmentPanel = qs(this.treatmentPanelSelector, thisResult);
-
-            // Apply the other treatment settings for this result to its
-            // treatment panel.
-            treatmentPanel.style.backgroundColor =
-                tailoringEntry.treatment.backgroundColor;
-            treatmentPanel.style.borderColor =
-                tailoringEntry.treatment.borderColor;
+            this.applyTreatment(thisResult, tailoringEntry.treatment);
         });
+    }
+
+    /**
+     * Applies the given treatment to the provided search result element.
+     *
+     * @param {Element} searchResult The search result element to apply the treatment to.
+     * @param {Object} treatment The treatment settings to apply to this element.
+     */
+    applyTreatment(searchResult, treatment) {
+        const thisResult = searchResult;
+
+        // If this result's treatment is set to an opacity of 0, screen the
+        // result completely.
+        if (treatment.opacity === 0) {
+            thisResult.style.display = "none";
+            return;
+        }
+
+        // Ensure this result element is visible and apply it's treatment's
+        // opacity setting directly.
+        thisResult.style.display = null;
+        thisResult.style.opacity = treatment.opacity;
+
+        const treatmentPanel = qs(this.treatmentPanelSelector, thisResult);
+
+        // Apply the other treatment settings for this result to its
+        // treatment panel.
+        treatmentPanel.style.backgroundColor = treatment.backgroundColor;
+        treatmentPanel.style.borderColor = treatment.borderColor;
+    }
+
+    /**
+     * Removes all alterations applied by the extension from the provided
+     * search result element.
+     *
+     * @param searchResult The search result element to remove a treatment from.
+     */
+    removeTreatment(searchResult) {
+        const thisResult = searchResult;
+
+        delete thisResult.dataset.tailoringEntryId;
+        thisResult.style.opacity = null;
+        thisResult.style.display = null;
+        qs(this.treatmentPanelSelector, thisResult).remove();
     }
 }
 

--- a/src/scripts/addon.js
+++ b/src/scripts/addon.js
@@ -73,9 +73,7 @@ class TailoredSearch {
     tailor(tailoringEntryIDs = null) {
         this.applyEntryIdAttributes(tailoringEntryIDs);
         this.insertTreatmentPanels();
-        this.applyTreatments(tailoringEntryIDs);
-
-        this.pruneTailoredResults();
+        this.updateTreatments(tailoringEntryIDs);
     }
 
     /**
@@ -153,13 +151,13 @@ class TailoredSearch {
                       );
 
                 if (!isMatchingResult) {
-                    // If this result no longer matches a tailoring entry, mark
-                    // it for pruning.
+                    // If this result no longer matches a tailoring entry,
+                    // remove its entry ID attribute so it will be pruned.
                     if (
                         thisResult.dataset.tailoringEntryId ===
                         tailoringEntry.id
                     ) {
-                        thisResult.dataset.tailoringEntryId = "prune";
+                        thisResult.dataset.tailoringEntryId = "";
                     }
 
                     return;
@@ -198,33 +196,12 @@ class TailoredSearch {
     }
 
     /**
-     * Removes all tailoring entries marked for pruning.
-     */
-    pruneTailoredResults() {
-        // Identify all search results that have been marked for pruning.
-        const resultsToPrune = this.searchResults.filter(
-            searchResult => searchResult.dataset.tailoringEntryId === "prune"
-        );
-
-        // Prune each marked result, removing all alterations applied by the
-        // extension.
-        resultsToPrune.forEach(entryToPrune => {
-            const thisEntry = entryToPrune;
-
-            delete thisEntry.dataset.tailoringEntryId;
-            thisEntry.style.opacity = null;
-            thisEntry.style.display = null;
-            qs(this.treatmentPanelSelector, thisEntry).remove();
-        });
-    }
-
-    /**
-     * Applies the appropriate tailoring entry's treatment settings to each
-     * search result marked with an entry's ID.
+     * Updates the current treatment of each search result that currently has a
+     * tailoring entry ID, adding, changing, or removing it as appropriate.
      *
      * @param {string[]} tailoringEntryIDs The IDs of the tailoring entries to apply treatments for, defaulting to all.
      */
-    applyTreatments(tailoringEntryIDs = null) {
+    updateTreatments(tailoringEntryIDs = null) {
         // Apply treatments to all tailored results by default.
         let searchResultsToTailor = this.tailoredSearchResults;
 
@@ -244,6 +221,16 @@ class TailoredSearch {
             const tailoringEntry = addonData.runtime.tailoringEntries.find(
                 entry => entry.id === thisResult.dataset.tailoringEntryId
             );
+
+            // If this result has no applicable entry, remove any existing
+            // alterations applied by the extension.
+            if (!tailoringEntry) {
+                delete thisResult.dataset.tailoringEntryId;
+                thisResult.style.opacity = null;
+                thisResult.style.display = null;
+                qs(this.treatmentPanelSelector, thisResult).remove();
+                return;
+            }
 
             // If this result's treatment is set to an opacity of 0, screen the
             // result completely.

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -80,22 +80,22 @@ main {
     border-top: 1px solid var(--color-entry-divider);
     display: flex;
     flex-direction: column;
+    position: relative;
+
+    &::after {
+        bottom: 0;
+        content: "";
+        box-shadow: var(--shadow-elevation-1);
+        height: 1px;
+        position: absolute;
+        width: 100%;
+        z-index: -1;
+    }
 
     &:last-child {
         margin-bottom: calc(
             var(--action-bar-height) + (var(--action-bar-padding) * 2)
         );
-        position: relative;
-
-        &::after {
-            bottom: 0;
-            content: "";
-            box-shadow: var(--shadow-elevation-1);
-            height: 1px;
-            position: absolute;
-            width: 100%;
-            z-index: -1;
-        }
     }
 
     // .entry__primary-ui

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -75,11 +75,13 @@ main {
 
 .entry {
     $thisEntry: &;
+    --entry-height: auto;
 
     background-color: var(--color-entry);
     border-top: 1px solid var(--color-entry-divider);
     display: flex;
     flex-direction: column;
+    height: var(--entry-height);
     position: relative;
 
     &::after {
@@ -96,6 +98,41 @@ main {
         margin-bottom: calc(
             var(--action-bar-height) + (var(--action-bar-padding) * 2)
         );
+    }
+
+    &[data-is-being-deleted="true"] {
+        animation: deleteEntry 700ms forwards;
+        pointer-events: none;
+    }
+
+    // Slide-and-shrink animation for entry deletion.
+    @keyframes deleteEntry {
+        // Begin with unaltered values. Height is set to a static value with
+        // JavaScript before triggering the animation via data attribute.
+        0% {
+            height: var(--entry-height);
+            opacity: 1;
+            overflow: visible;
+            translate: 0;
+        }
+
+        // Slide the entry out to the right and set its overflow to hidden to
+        // prevent any child elements from propping the entry container open.
+        50% {
+            height: var(--entry-height);
+            opacity: 1;
+            overflow: hidden;
+            translate: 100%;
+        }
+
+        // Shrink the entry down to nothing. JavaScript will listen for the
+        // animationend event and finally remove the entry from the DOM.
+        100% {
+            height: 0;
+            opacity: 0;
+            overflow: hidden;
+            translate: 100%;
+        }
     }
 
     // .entry__primary-ui


### PR DESCRIPTION
This branch fixes and improves the experience for deleting entries.

- Deleting an entry now has a fancy animation, because everyone's last moments should be special.
- Deleting an entry now immediately updates any open search results Sometimes reaching for that refresh button is just too much effort.
- Updating an entry's domains now updates all search results, instead of just the ones that apply to that entry. This only made things weird if you had conflicting domains—but you would never do that, would you?