### PR TITLE
Add color hints to entries

### DIFF
--- a/src/markup/includes/tailoring-entry.pug
+++ b/src/markup/includes/tailoring-entry.pug
@@ -1,6 +1,8 @@
 template(id="tailoring-entry")
     div(class="entry js-entry")
         div(class="entry__primary-ui")
+            div(class="entry__color-hint")
+
             div(class="entry__sort-handle js-sort-handle")
                 svg(class="entry__sort-handle__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24")
                     path(fill="none" d="M0 0h24v24H0V0z")

--- a/src/markup/popup.pug
+++ b/src/markup/popup.pug
@@ -8,7 +8,7 @@ html
         style(type='text/css').
             body {
                 height: 420px;
-                min-width: 374px;
+                width: 370px;
             }
 
     body

--- a/src/markup/popup.pug
+++ b/src/markup/popup.pug
@@ -7,7 +7,9 @@ html
 
         style(type='text/css').
             body {
+                box-shadow: 0 0 1px 3px hsla(0, 0%, 0%, 0.25);
                 height: 420px;
+                margin: 0 auto;
                 width: 370px;
             }
 

--- a/src/scripts/TailoringEntry.js
+++ b/src/scripts/TailoringEntry.js
@@ -530,15 +530,15 @@ class TailoringEntry {
      */
     updateColoredIcons(iconsToUpdate = ["backgroundColor", "borderColor"]) {
         if (iconsToUpdate.includes("backgroundColor")) {
-            this.actionButtons.showBackgroundColorModal.style.setProperty(
-                "--color-icon-fill-background-picker",
+            this.element.style.setProperty(
+                "--color-treatment-background",
                 this.settings.treatment.backgroundColor
             );
         }
 
         if (iconsToUpdate.includes("borderColor")) {
-            this.actionButtons.showBorderColorModal.style.setProperty(
-                "--color-icon-fill-border-picker",
+            this.element.style.setProperty(
+                "--color-treatment-border",
                 this.settings.treatment.borderColor
             );
         }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -26,8 +26,8 @@
     --color-entry-input: hsl(240, 3%, 37%);
 
     --color-icon-fill: hsl(240, 0%, 85%);
-    --color-icon-fill-background-picker: var(--color-icon-fill);
-    --color-icon-fill-border-picker: var(--color-icon-fill);
+    --color-treatment-background: var(--color-icon-fill);
+    --color-treatment-border: var(--color-icon-fill);
     --color-picker-scrim: hsla(0, 0%, 0%, 0.5);
 
     --color-input-highlight: hsla(200, 100%, 50%, 1);

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -531,11 +531,11 @@ main {
 
                 button:not([disabled]) & {
                     #{$entry-setting}--background-color & {
-                        fill: var(--color-icon-fill-background-picker);
+                        fill: var(--color-treatment-background);
                     }
 
                     #{$entry-setting}--border-color & {
-                        fill: var(--color-icon-fill-border-picker);
+                        fill: var(--color-treatment-border);
                     }
                 }
             }

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -217,6 +217,17 @@ main {
         display: flex;
     }
 
+    //. entry__color-hint
+    &__color-hint {
+        background-image: linear-gradient(
+            var(--color-treatment-background) 50%,
+            var(--color-treatment-border) 50%
+        );
+        border-radius: 0 4px 4px 0;
+        flex: 0 0 4px;
+        height: 40px;
+    }
+
     // .entry__sort-handle
     &__sort-handle {
         cursor: move;

--- a/src/styles/popup.scss
+++ b/src/styles/popup.scss
@@ -232,6 +232,7 @@ main {
     &__sort-handle {
         cursor: move;
         flex: 0 0 auto;
+        margin: 0 2px;
 
         // .entry__sort-handle__icon
         &__icon {
@@ -246,7 +247,7 @@ main {
         background-color: var(--color-entry-input);
         border-radius: var(--input-radius);
         flex: 1 1 100%;
-        margin: 15px 0 15px 2px;
+        margin: 15px 0;
         position: relative;
         overflow: hidden;
 


### PR DESCRIPTION
This branch implements color hints to each entry in the popup interface, giving users a way to visually parse their entries based on the colors they've assigned to them.