### PR TITLE
Ensure tailoring visibility in Google searches

### DIFF
--- a/src/styles/tab.scss
+++ b/src/styles/tab.scss
@@ -13,7 +13,7 @@
             border: 1px solid transparent;
             background-color: transparent;
             position: absolute;
-            z-index: -1;
+            z-index: 0;
         }
     }
 }


### PR DESCRIPTION
Resolves #45 by addressing the layering issue revealed by Dark Reader. We're applying a `z-index` of 0, which is _technically_ the default, but better kept explicit.